### PR TITLE
hooks to before:offline:start when custom.writeEnvVarsOffline is true

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,10 @@ module.exports = Class.extend({
          'before:deploy:createDeploymentArtifacts': this.writeEnvironmentFile.bind(this),
          'after:deploy:createDeploymentArtifacts': this.deleteEnvironmentFile.bind(this),
       };
+
+      if (this._serverless && this._serverless.service && this._serverless.service.custom.writeEnvVarsOffline) {
+         this.hooks['before:offline:start'] = this.writeEnvironmentFile.bind(this);
+      }
    },
 
    getEnvFilePath: function() {

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ module.exports = Class.extend({
 
       if (this._serverless && this._serverless.service && this._serverless.service.custom.writeEnvVarsOffline) {
          this.hooks['before:offline:start'] = this.writeEnvironmentFile.bind(this);
+         this.hooks['before:offline:start:init'] = this.writeEnvironmentFile.bind(this);
       }
    },
 

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -45,7 +45,10 @@ describe('serverless-plugin-write-env-vars', function() {
       testHookRegistration('after:deploy:createDeploymentArtifacts', 'deleteEnvironmentFile');
 
       it('registers before:offline:start that calls writeEnvironmentFile when configured to do so', function() {
-         var sls, plugin;
+         var sls, plugin,
+             spy = sinon.spy(),
+             functions = {},
+             ExtPlugin, hook, fn;
 
          sls = {
             service: { custom: { writeEnvVarsOffline: true } },
@@ -55,7 +58,19 @@ describe('serverless-plugin-write-env-vars', function() {
          plugin = new Plugin(sls);
 
          expect(plugin.hooks['before:offline:start']).to.be.a('function');
-         expect(plugin.hooks['before:offline:start'].name).to.be('bound writeEnvironmentFile');
+
+         // inlining testHookRegistration to pass it our serverless 'instance' with the config option enabled
+         hook = 'before:offline:start';
+         fn = 'writeEnvironmentFile';
+
+         functions[fn] = spy;
+         ExtPlugin = Plugin.extend(functions);
+
+         plugin = new ExtPlugin(sls);
+         plugin.hooks[hook]();
+
+         expect(spy.called).to.be.ok();
+         expect(spy.calledOn(plugin));
       });
 
    });

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -18,6 +18,7 @@ describe('serverless-plugin-write-env-vars', function() {
          expect(plugin.hooks['after:deploy:function:deploy']).to.be.a('function');
          expect(plugin.hooks['before:deploy:createDeploymentArtifacts']).to.be.a('function');
          expect(plugin.hooks['after:deploy:createDeploymentArtifacts']).to.be.a('function');
+         expect(plugin.hooks['before:offline:start']).to.be(undefined);
       });
 
 
@@ -42,6 +43,20 @@ describe('serverless-plugin-write-env-vars', function() {
       testHookRegistration('after:deploy:function:deploy', 'deleteEnvironmentFile');
       testHookRegistration('before:deploy:createDeploymentArtifacts', 'writeEnvironmentFile');
       testHookRegistration('after:deploy:createDeploymentArtifacts', 'deleteEnvironmentFile');
+
+      it('registers before:offline:start that calls writeEnvironmentFile when configured to do so', function() {
+         var sls, plugin;
+
+         sls = {
+            service: { custom: { writeEnvVarsOffline: true } },
+            cli: { log: _.noop },
+         };
+
+         plugin = new Plugin(sls);
+
+         expect(plugin.hooks['before:offline:start']).to.be.a('function');
+         expect(plugin.hooks['before:offline:start'].name).to.be('bound writeEnvironmentFile');
+      });
 
    });
 


### PR DESCRIPTION
It might be desirable to work with the offline plugin by default.

And the qualifiers of `this._serverless` and `this._serverless.service` are there only to ensure the existing tests don't break.  I figured it was more clean to include these than to change every existing test.
